### PR TITLE
Make compatible with web3 1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,8 +71,8 @@ Web3ProviderEngine.prototype.addProvider = function(source){
   source.setEngine(this)
 }
 
-Web3ProviderEngine.prototype.send = function(payload){
-  throw new Error('Web3ProviderEngine does not support synchronous requests.')
+Web3ProviderEngine.prototype.send = function(payload, cb){
+  this.sendAsync(payload, cb);
 }
 
 Web3ProviderEngine.prototype.sendAsync = function(payload, cb){

--- a/subproviders/provider.js
+++ b/subproviders/provider.js
@@ -9,12 +9,11 @@ inherits(ProviderSubprovider, Subprovider)
 
 function ProviderSubprovider(provider){
   if (!provider) throw new Error('ProviderSubprovider - no provider specified')
-  if (!provider.sendAsync) throw new Error('ProviderSubprovider - specified provider does not have a sendAsync method')
   this.provider = provider
 }
 
 ProviderSubprovider.prototype.handleRequest = function(payload, next, end){
-  this.provider.sendAsync(payload, function(err, response) {
+  this.provider.send(payload, function(err, response) {
     if (err) return end(err)
     if (response.error) return end(new Error(response.error.message))
     end(null, response.result)


### PR DESCRIPTION
+ Aliases `send` to `sendAsync` and uses it handle requests
+ Removes error checking that precludes use with web3 1.0 because it has removed its own `sendAsync` method and now uses `send` for async.

Question: should we publish the `web3-one`  branch as `truffle-provider-engine` and consume it truffle-hdwallet-provider like that? Or just install the dep at a commit hash here?