### PR TITLE
Updates nonce cache in response to an EVM Revert

### DIFF
--- a/subproviders/nonce-tracker.js
+++ b/subproviders/nonce-tracker.js
@@ -10,7 +10,7 @@ module.exports = NonceTrackerSubprovider
 //   eth_getTransactionCount (pending only)
 // observes the following RPC methods:
 //   eth_sendRawTransaction
-
+//   evm_revert (to clear the nonce cache)
 
 inherits(NonceTrackerSubprovider, Subprovider)
 
@@ -73,6 +73,12 @@ NonceTrackerSubprovider.prototype.handleRequest = function(payload, next, end){
         self.nonceCache[address] = hexNonce
         cb()
       })
+      return
+
+   // Clear cache on a testrpc revert
+   case 'evm_revert':
+      self.nonceCache = {}
+      next()
       return
 
     default:


### PR DESCRIPTION
While looking to an issue of HDWallet provider not responding gracefully in terms of nonces being used after encountering an evm_revert, I came across some code that has been added to the upstream of this base library but not added here to resolve this issue. 

In order to keep the nonce cache useful in the case of a revert, the revert is being responded to with a clear of the cache.

This is lifted from the upstream pull request: https://github.com/MetaMask/web3-provider-engine/pull/299